### PR TITLE
feat(plan): add planning tool for goal decomposition

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -27,6 +27,8 @@ from core.composable import (
     ComposableAgent,
     AgentBuilder,
 )
+from core.context import ExecutionContext
+from core.utils import extract_json
 
 from llm.client import NanoLLMClient
 from tools.registry import get_tool_registry
@@ -53,6 +55,8 @@ __all__ = [
     "get_global_registry",
     "ComposableAgent",
     "AgentBuilder",
+    "ExecutionContext",
+    "extract_json",
     "NanoLLMClient",
     "get_tool_registry",
 ]

--- a/core/chain.py
+++ b/core/chain.py
@@ -3,38 +3,8 @@
 import asyncio
 import json
 from typing import Any, Callable, Dict, List, Optional, Union
-from datetime import datetime
 
-
-class ChainContext:
-    """链式执行上下文"""
-
-    def __init__(self, initial_data: Optional[Dict[str, Any]] = None):
-        self.data: Dict[str, Any] = initial_data or {}
-        self.history: List[Dict[str, Any]] = []
-        self.metadata: Dict[str, Any] = {}
-
-    def set(self, key: str, value: Any) -> None:
-        """设置上下文数据"""
-        self.data[key] = value
-
-    def get(self, key: str, default: Any = None) -> Any:
-        """获取上下文数据"""
-        return self.data.get(key, default)
-
-    def add_history(self, step_name: str, result: Any) -> None:
-        """添加执行历史"""
-        self.history.append(
-            {
-                "step": step_name,
-                "result": result,
-                "timestamp": datetime.now().isoformat(),
-            }
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
-        return {"data": self.data, "history": self.history, "metadata": self.metadata}
+from core.context import ChainContext
 
 
 class ChainResult:

--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,47 @@
+"""共享上下文基类"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List
+
+
+@dataclass
+class ExecutionContext:
+    """执行上下文基类 - ChainContext 和 RouteContext 的共享实现"""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+    history: List[Dict[str, Any]] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def set(self, key: str, value: Any) -> None:
+        """设置上下文数据"""
+        self.data[key] = value
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """获取上下文数据"""
+        return self.data.get(key, default)
+
+    def add_history(self, **kwargs) -> None:
+        """添加执行历史 - 子类实现具体的记录格式"""
+        self.history.append({**kwargs, "timestamp": datetime.now().isoformat()})
+
+    def to_dict(self) -> Dict[str, Any]:
+        """转换为字典"""
+        return {"data": self.data, "history": self.history, "metadata": self.metadata}
+
+
+class ChainContext(ExecutionContext):
+    """链式执行上下文"""
+
+    def add_history(self, step_name: str, result: Any) -> None:
+        super().add_history(step=step_name, result=result)
+
+
+class RouteContext(ExecutionContext):
+    """路由上下文"""
+
+    def add_history(self, decision: Any, task: str) -> None:
+        super().add_history(
+            task=task,
+            decision=decision.to_dict() if hasattr(decision, "to_dict") else decision,
+        )

--- a/core/router.py
+++ b/core/router.py
@@ -4,7 +4,8 @@ import asyncio
 import json
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union
-from datetime import datetime
+
+from core.context import RouteContext
 
 
 @dataclass
@@ -17,7 +18,6 @@ class RouteDecision:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
         return {
             "target": self.target,
             "reasoning": self.reasoning,
@@ -37,43 +37,11 @@ class Route:
     description: str = ""
 
     def matches(self, task: str) -> bool:
-        """检查任务是否匹配此路由"""
         if isinstance(self.condition, str):
             return self.condition.lower() in task.lower()
         elif callable(self.condition):
             return self.condition(task)
         return False
-
-
-class RouteContext:
-    """路由上下文"""
-
-    def __init__(self, initial_data: Optional[Dict[str, Any]] = None):
-        self.data: Dict[str, Any] = initial_data or {}
-        self.history: List[Dict[str, Any]] = []
-        self.metadata: Dict[str, Any] = {}
-
-    def set(self, key: str, value: Any) -> None:
-        """设置上下文数据"""
-        self.data[key] = value
-
-    def get(self, key: str, default: Any = None) -> Any:
-        """获取上下文数据"""
-        return self.data.get(key, default)
-
-    def add_history(self, decision: RouteDecision, task: str) -> None:
-        """添加路由历史"""
-        self.history.append(
-            {
-                "task": task,
-                "decision": decision.to_dict(),
-                "timestamp": datetime.now().isoformat(),
-            }
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        """转换为字典"""
-        return {"data": self.data, "history": self.history, "metadata": self.metadata}
 
 
 class Router:

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,22 @@
+"""Shared utilities"""
+
+import json
+import re
+
+
+def extract_json(text: str) -> dict:
+    """Extract JSON object from text, handling markdown code blocks and plain JSON.
+
+    Finds the first {...} block or JSON inside ```json ``` fences.
+    """
+    # 提取 markdown 代码块中的 JSON
+    match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text)
+    if match:
+        text = match.group(1).strip()
+
+    # 查找 JSON 对象的起始和结束位置
+    start, end = text.find("{"), text.rfind("}")
+    if start != -1 and end > start:
+        return json.loads(text[start : end + 1])
+
+    return json.loads(text)

--- a/llm/client.py
+++ b/llm/client.py
@@ -4,9 +4,8 @@ import asyncio
 import json
 import os
 import random
-import re
 import time
-from typing import Dict, List, Optional, Type, TypeVar
+from typing import Dict, List, Optional, Type, TypeVar  # noqa: E402, F401
 
 import litellm
 from dotenv import load_dotenv
@@ -336,15 +335,4 @@ class NanoLLMClient:
         return response_model.model_validate(data)
 
 
-def _extract_json(text: str) -> dict:
-    # 提取 markdown 代码块中的 JSON
-    match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text)
-    if match:
-        text = match.group(1).strip()
-
-    # 查找 JSON 对象的起始和结束位置
-    start, end = text.find("{"), text.rfind("}")
-    if start != -1 and end > start:
-        return json.loads(text[start : end + 1])
-
-    return json.loads(text)
+from core.utils import extract_json as _extract_json  # noqa: E402

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -11,35 +11,35 @@ if str(project_root) not in sys.path:
 
 
 class TestExtractJson:
-    """测试 JSON 解析（复用 llm.client 的逻辑）"""
+    """测试 JSON 解析（复用 core.utils 的逻辑）"""
 
     def test_extract_json_basic(self):
-        from llm.client import _extract_json
+        from core.utils import extract_json
 
         text = '{"steps": [{"step": 1}], "total": 1}'
-        result = _extract_json(text)
+        result = extract_json(text)
         assert result["total"] == 1
         assert len(result["steps"]) == 1
 
     def test_extract_json_with_prefix_suffix(self):
-        from llm.client import _extract_json
+        from core.utils import extract_json
 
         text = 'Here is the plan:\n{"steps": [{"step": 1}], "total_steps": 1}\nDone.'
-        result = _extract_json(text)
+        result = extract_json(text)
         assert result["total_steps"] == 1
 
     def test_extract_json_markdown_code_block(self):
-        from llm.client import _extract_json
+        from core.utils import extract_json
 
         text = '```json\n{"steps": [{"step": 1}], "total_steps": 1}\n```'
-        result = _extract_json(text)
+        result = extract_json(text)
         assert result["total_steps"] == 1
 
     def test_extract_json_invalid(self):
-        from llm.client import _extract_json
+        from core.utils import extract_json
 
         with pytest.raises(Exception):
-            _extract_json("no json here")
+            extract_json("no json here")
 
 
 class _MockLLM:
@@ -59,7 +59,6 @@ class _MockLLM:
 
 def _patch_llm(monkeypatch, response_or_error):
     mock = _MockLLM(response_or_error)
-    from llm.client import _extract_json as ej
 
     class MockNanoLLMClient:
         def __init__(self, model=None):
@@ -73,9 +72,12 @@ def _patch_llm(monkeypatch, response_or_error):
 
     class MockModule:
         NanoLLMClient = MockNanoLLMClient
-        _extract_json = ej
 
     monkeypatch.setitem(sys.modules, "llm.client", MockModule())
+    # 清除 plan.py 的缓存 client
+    import tools.plan as plan_module
+
+    monkeypatch.setattr(plan_module, "_llm_client", None)
 
 
 class TestPlanInputValidation:
@@ -223,9 +225,7 @@ class TestPlanAsync:
         _patch_llm(monkeypatch, mock_response)
         from tools.plan import aplan
 
-        result = asyncio.get_event_loop().run_until_complete(
-            aplan("异步规划测试")
-        )
+        result = asyncio.run(aplan("异步规划测试"))
 
         assert "plan_id" in result
         assert result["total_steps"] == 1
@@ -235,7 +235,7 @@ class TestPlanAsync:
         _patch_llm(monkeypatch, "unexpected")
         from tools.plan import aplan
 
-        result = asyncio.get_event_loop().run_until_complete(aplan(""))
+        result = asyncio.run(aplan(""))
         assert "error" in result
         assert "empty" in result["error"]
 
@@ -243,9 +243,7 @@ class TestPlanAsync:
         _patch_llm(monkeypatch, RuntimeError("async error"))
         from tools.plan import aplan
 
-        result = asyncio.get_event_loop().run_until_complete(
-            aplan("分析项目")
-        )
+        result = asyncio.run(aplan("分析项目"))
         assert "error" in result
         assert "LLM" in result["error"]
 
@@ -267,7 +265,9 @@ class TestPlanRegistration:
         reg = registry_module.get_tool_registry()
 
         tool_list = reg.get_tool_list()
-        plan_tool = next((t for t in tool_list if t["function"]["name"] == "plan"), None)
+        plan_tool = next(
+            (t for t in tool_list if t["function"]["name"] == "plan"), None
+        )
         assert plan_tool is not None
         props = plan_tool["function"]["parameters"]["properties"]
         assert "goal" in props

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,234 @@
+"""测试规划工具"""
+
+import pytest
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+
+class TestExtractJson:
+    """测试 JSON 解析辅助函数"""
+
+    def test_extract_json_basic(self):
+        from tools.plan import _extract_json
+
+        text = '{"steps": [{"step": 1}], "total": 1}'
+        result = _extract_json(text)
+        assert result["total"] == 1
+        assert len(result["steps"]) == 1
+
+    def test_extract_json_with_prefix_suffix(self):
+        from tools.plan import _extract_json
+
+        text = 'Here is the plan:\n{"steps": [{"step": 1}], "total_steps": 1}\nDone.'
+        result = _extract_json(text)
+        assert result["total_steps"] == 1
+
+    def test_extract_json_invalid(self):
+        from tools.plan import _extract_json
+
+        with pytest.raises(ValueError):
+            _extract_json("no json here")
+
+
+class TestPlanTool:
+    """测试规划工具"""
+
+    def _make_mock_module(self, response_or_error):
+        """创建一个 mock llm.client 模块"""
+        if isinstance(response_or_error, Exception):
+
+            class FailLLM:
+                def __init__(self):
+                    pass
+
+                def chat(self, msgs):
+                    raise response_or_error
+
+            MockClass = FailLLM
+        else:
+
+            class MockLLM:
+                def __init__(self):
+                    pass
+
+                def chat(self, msgs):
+                    return response_or_error
+
+            MockClass = MockLLM
+
+        mock_mod = type("MockLLMClientModule", (), {"NanoLLMClient": MockClass})()
+        return mock_mod
+
+    def test_plan_returns_structure(self, monkeypatch):
+        """测试 plan 返回正确的结构"""
+        mock_response = """{
+  "steps": [
+    {
+      "step": 1,
+      "description": "Read project structure",
+      "reasoning": "Need to understand codebase first",
+      "complexity": "低"
+    }
+  ],
+  "total_steps": 1,
+  "reasoning": "Start by understanding the project",
+  "estimated_difficulty": "低",
+  "potential_risks": []
+}"""
+        mock_module = self._make_mock_module(mock_response)
+        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
+
+        from tools.plan import plan
+
+        result = plan("分析这个项目")
+
+        assert "plan_id" in result
+        assert "steps" in result
+        assert result["total_steps"] == 1
+        assert len(result["steps"]) == 1
+        assert result["steps"][0]["step"] == 1
+        assert result["steps"][0]["description"] == "Read project structure"
+        assert result["estimated_difficulty"] == "低"
+
+    def test_plan_with_current_state(self, monkeypatch):
+        """测试带当前状态的规划"""
+        mock_response = '{"steps": [{"step": 1, "description": "Continue analysis", "reasoning": "Given current state", "complexity": "低"}], "total_steps": 1, "reasoning": "resume from current", "estimated_difficulty": "低", "potential_risks": []}'
+        mock_module = self._make_mock_module(mock_response)
+        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
+
+        from tools.plan import plan
+
+        result = plan(
+            goal="完成项目分析",
+            current_state={"files_analyzed": ["README.md", "core/agent.py"]},
+        )
+
+        assert result["total_steps"] == 1
+
+    def test_plan_with_constraints(self, monkeypatch):
+        """测试带约束条件的规划"""
+        mock_response = '{"steps": [{"step": 1, "description": "Plan with constraints", "reasoning": "Applied", "complexity": "中"}], "total_steps": 1, "reasoning": "test", "estimated_difficulty": "中", "potential_risks": []}'
+        mock_module = self._make_mock_module(mock_response)
+        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
+
+        from tools.plan import plan
+
+        result = plan(
+            goal="重构代码",
+            constraints=["必须保持向后兼容", "不超过5步"],
+        )
+
+        assert result["total_steps"] == 1
+
+    def test_plan_llm_error(self, monkeypatch):
+        """测试 LLM 调用失败时的处理"""
+        mock_module = self._make_mock_module(RuntimeError("LLM unavailable"))
+        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
+
+        from tools.plan import plan
+
+        result = plan("分析项目")
+        assert "error" in result
+        assert "LLM" in result["error"]
+        assert result["total_steps"] == 0
+        assert "plan_id" in result
+
+    def test_plan_invalid_json_response(self, monkeypatch):
+        """测试 LLM 返回无效 JSON 时的处理"""
+        mock_module = self._make_mock_module("This is not JSON at all")
+        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
+
+        from tools.plan import plan
+
+        result = plan("分析项目")
+        assert "error" in result
+        assert "解析" in result["error"]
+
+
+class TestPlanToolRegistration:
+    """测试规划工具注册"""
+
+    def test_plan_registered_in_registry(self):
+        """验证 plan 工具已注册"""
+        # 需要清除已有的 registry 单例以获取最新的
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        tool_names = list(reg._tools.keys())
+        assert "plan" in tool_names
+        assert "read_file" in tool_names
+        assert "list_files" in tool_names
+
+    def test_plan_tool_in_tool_list(self):
+        """验证 plan 工具在工具列表中"""
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        tool_list = reg.get_tool_list()
+        plan_tool = next((t for t in tool_list if t["function"]["name"] == "plan"), None)
+        assert plan_tool is not None
+        assert "goal" in plan_tool["function"]["parameters"]["properties"]
+        assert "current_state" in plan_tool["function"]["parameters"]["properties"]
+        assert "constraints" in plan_tool["function"]["parameters"]["properties"]
+
+    def test_plan_tool_executable(self, monkeypatch):
+        """测试通过 registry 执行 plan 工具"""
+        mock_response = '{"steps": [{"step": 1, "description": "Test step", "reasoning": "Test", "complexity": "低"}], "total_steps": 1, "reasoning": "Test", "estimated_difficulty": "低", "potential_risks": []}'
+
+        class MockLLM:
+            def __init__(self):
+                pass
+
+            def chat(self, msgs):
+                return mock_response
+
+        mock_module = type("MockLLMClientModule", (), {"NanoLLMClient": MockLLM})()
+        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
+
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        result = reg.execute("plan", {"goal": "测试目标"})
+        assert "plan_id" in result
+        assert "steps" in result
+        assert result["total_steps"] == 1
+
+
+class TestPlanSchema:
+    """测试规划工具的 schema"""
+
+    def test_plan_schema_goal_required(self):
+        """验证 goal 是必需参数"""
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        tool = reg._tools["plan"]
+        required = tool["schema"]["required"]
+        assert "goal" in required
+
+    def test_plan_schema_optional_params(self):
+        """验证 current_state 和 constraints 是可选参数"""
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        tool = reg._tools["plan"]
+        props = tool["schema"]["properties"]
+        assert "goal" in props
+        assert "current_state" in props
+        assert "constraints" in props
+        assert "default" in props["current_state"]
+        assert props["current_state"]["default"] is None

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -2,6 +2,7 @@
 
 import pytest
 import sys
+import asyncio
 from pathlib import Path
 
 project_root = Path(__file__).parent.parent
@@ -10,10 +11,10 @@ if str(project_root) not in sys.path:
 
 
 class TestExtractJson:
-    """测试 JSON 解析辅助函数"""
+    """测试 JSON 解析（复用 llm.client 的逻辑）"""
 
     def test_extract_json_basic(self):
-        from tools.plan import _extract_json
+        from llm.client import _extract_json
 
         text = '{"steps": [{"step": 1}], "total": 1}'
         result = _extract_json(text)
@@ -21,50 +22,105 @@ class TestExtractJson:
         assert len(result["steps"]) == 1
 
     def test_extract_json_with_prefix_suffix(self):
-        from tools.plan import _extract_json
+        from llm.client import _extract_json
 
         text = 'Here is the plan:\n{"steps": [{"step": 1}], "total_steps": 1}\nDone.'
         result = _extract_json(text)
         assert result["total_steps"] == 1
 
-    def test_extract_json_invalid(self):
-        from tools.plan import _extract_json
+    def test_extract_json_markdown_code_block(self):
+        from llm.client import _extract_json
 
-        with pytest.raises(ValueError):
+        text = '```json\n{"steps": [{"step": 1}], "total_steps": 1}\n```'
+        result = _extract_json(text)
+        assert result["total_steps"] == 1
+
+    def test_extract_json_invalid(self):
+        from llm.client import _extract_json
+
+        with pytest.raises(Exception):
             _extract_json("no json here")
 
 
-class TestPlanTool:
-    """测试规划工具"""
+class _MockLLM:
+    def __init__(self, response_or_error):
+        self._response = response_or_error
 
-    def _make_mock_module(self, response_or_error):
-        """创建一个 mock llm.client 模块"""
-        if isinstance(response_or_error, Exception):
+    def chat(self, msgs):
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
 
-            class FailLLM:
-                def __init__(self):
-                    pass
+    async def achat(self, msgs):
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
 
-                def chat(self, msgs):
-                    raise response_or_error
 
-            MockClass = FailLLM
-        else:
+def _patch_llm(monkeypatch, response_or_error):
+    mock = _MockLLM(response_or_error)
+    from llm.client import _extract_json as ej
 
-            class MockLLM:
-                def __init__(self):
-                    pass
+    class MockNanoLLMClient:
+        def __init__(self, model=None):
+            self._mock = mock
 
-                def chat(self, msgs):
-                    return response_or_error
+        def chat(self, msgs):
+            return self._mock.chat(msgs)
 
-            MockClass = MockLLM
+        async def achat(self, msgs):
+            return await self._mock.achat(msgs)
 
-        mock_mod = type("MockLLMClientModule", (), {"NanoLLMClient": MockClass})()
-        return mock_mod
+    class MockModule:
+        NanoLLMClient = MockNanoLLMClient
+        _extract_json = ej
+
+    monkeypatch.setitem(sys.modules, "llm.client", MockModule())
+
+
+class TestPlanInputValidation:
+    """测试输入验证"""
+
+    def test_empty_goal(self, monkeypatch):
+        _patch_llm(monkeypatch, "unexpected")
+        from tools.plan import plan
+
+        result = plan("")
+        assert "error" in result
+        assert "empty" in result["error"]
+        assert result["total_steps"] == 0
+
+    def test_whitespace_goal(self, monkeypatch):
+        _patch_llm(monkeypatch, "unexpected")
+        from tools.plan import plan
+
+        result = plan("   ")
+        assert "error" in result
+        assert "empty" in result["error"]
+
+    def test_invalid_current_state_type(self, monkeypatch):
+        _patch_llm(monkeypatch, "unexpected")
+        from tools.plan import plan
+
+        result = plan("分析项目", current_state="not a dict")
+        assert "error" in result
+        assert "current_state" in result["error"]
+        assert result["total_steps"] == 0
+
+    def test_invalid_constraints_type(self, monkeypatch):
+        _patch_llm(monkeypatch, "unexpected")
+        from tools.plan import plan
+
+        result = plan("分析项目", constraints="not a list")
+        assert "error" in result
+        assert "constraints" in result["error"]
+        assert result["total_steps"] == 0
+
+
+class TestPlanLLMIntegration:
+    """测试 LLM 集成"""
 
     def test_plan_returns_structure(self, monkeypatch):
-        """测试 plan 返回正确的结构"""
         mock_response = """{
   "steps": [
     {
@@ -79,9 +135,7 @@ class TestPlanTool:
   "estimated_difficulty": "低",
   "potential_risks": []
 }"""
-        mock_module = self._make_mock_module(mock_response)
-        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
-
+        _patch_llm(monkeypatch, mock_response)
         from tools.plan import plan
 
         result = plan("分析这个项目")
@@ -90,83 +144,123 @@ class TestPlanTool:
         assert "steps" in result
         assert result["total_steps"] == 1
         assert len(result["steps"]) == 1
-        assert result["steps"][0]["step"] == 1
         assert result["steps"][0]["description"] == "Read project structure"
-        assert result["estimated_difficulty"] == "低"
 
     def test_plan_with_current_state(self, monkeypatch):
-        """测试带当前状态的规划"""
-        mock_response = '{"steps": [{"step": 1, "description": "Continue analysis", "reasoning": "Given current state", "complexity": "低"}], "total_steps": 1, "reasoning": "resume from current", "estimated_difficulty": "低", "potential_risks": []}'
-        mock_module = self._make_mock_module(mock_response)
-        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
-
+        mock_response = '{"steps": [{"step": 1, "description": "Continue", "reasoning": "ok", "complexity": "低"}], "total_steps": 1, "reasoning": "test", "estimated_difficulty": "低", "potential_risks": []}'
+        _patch_llm(monkeypatch, mock_response)
         from tools.plan import plan
 
         result = plan(
-            goal="完成项目分析",
-            current_state={"files_analyzed": ["README.md", "core/agent.py"]},
+            "完成项目分析",
+            current_state={"files_analyzed": ["README.md"]},
         )
 
         assert result["total_steps"] == 1
 
     def test_plan_with_constraints(self, monkeypatch):
-        """测试带约束条件的规划"""
-        mock_response = '{"steps": [{"step": 1, "description": "Plan with constraints", "reasoning": "Applied", "complexity": "中"}], "total_steps": 1, "reasoning": "test", "estimated_difficulty": "中", "potential_risks": []}'
-        mock_module = self._make_mock_module(mock_response)
-        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
-
+        mock_response = '{"steps": [{"step": 1, "description": "Plan with constraints", "reasoning": "ok", "complexity": "中"}], "total_steps": 1, "reasoning": "test", "estimated_difficulty": "中", "potential_risks": []}'
+        _patch_llm(monkeypatch, mock_response)
         from tools.plan import plan
 
-        result = plan(
-            goal="重构代码",
-            constraints=["必须保持向后兼容", "不超过5步"],
-        )
-
+        result = plan("重构代码", constraints=["保持兼容"])
         assert result["total_steps"] == 1
 
     def test_plan_llm_error(self, monkeypatch):
-        """测试 LLM 调用失败时的处理"""
-        mock_module = self._make_mock_module(RuntimeError("LLM unavailable"))
-        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
-
+        _patch_llm(monkeypatch, RuntimeError("LLM unavailable"))
         from tools.plan import plan
 
         result = plan("分析项目")
         assert "error" in result
         assert "LLM" in result["error"]
         assert result["total_steps"] == 0
-        assert "plan_id" in result
 
     def test_plan_invalid_json_response(self, monkeypatch):
-        """测试 LLM 返回无效 JSON 时的处理"""
-        mock_module = self._make_mock_module("This is not JSON at all")
-        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
-
+        _patch_llm(monkeypatch, "This is not JSON at all")
         from tools.plan import plan
 
         result = plan("分析项目")
         assert "error" in result
         assert "解析" in result["error"]
 
+    def test_plan_response_missing_steps_field(self, monkeypatch):
+        """LLM 返回有效 JSON 但缺少 steps 字段"""
+        mock_response = '{"total_steps": 5, "reasoning": "test"}'
+        _patch_llm(monkeypatch, mock_response)
+        from tools.plan import plan
 
-class TestPlanToolRegistration:
-    """测试规划工具注册"""
+        result = plan("分析项目")
+        assert "steps" in result
+        assert result["steps"] == []
+        assert result["total_steps"] == 0
 
-    def test_plan_registered_in_registry(self):
-        """验证 plan 工具已注册"""
-        # 需要清除已有的 registry 单例以获取最新的
+    def test_plan_response_steps_not_list(self, monkeypatch):
+        """LLM 返回有效 JSON 但 steps 不是列表"""
+        mock_response = '{"steps": "not a list", "total_steps": 0}'
+        _patch_llm(monkeypatch, mock_response)
+        from tools.plan import plan
+
+        result = plan("分析项目")
+        assert "steps" in result
+        assert result["steps"] == []
+
+    def test_plan_response_in_markdown(self, monkeypatch):
+        """LLM 返回 markdown 代码块包裹的 JSON"""
+        mock_response = """以下是计划:\n```json\n{"steps": [{"step": 1, "description": "First", "reasoning": "ok", "complexity": "低"}], "total_steps": 1, "reasoning": "test", "estimated_difficulty": "低", "potential_risks": []}\n```\n完成"""
+        _patch_llm(monkeypatch, mock_response)
+        from tools.plan import plan
+
+        result = plan("分析项目")
+        assert result["total_steps"] == 1
+        assert result["steps"][0]["description"] == "First"
+
+
+class TestPlanAsync:
+    """测试异步版本"""
+
+    def test_aplan_returns_structure(self, monkeypatch):
+        mock_response = '{"steps": [{"step": 1, "description": "Async step", "reasoning": "ok", "complexity": "低"}], "total_steps": 1, "reasoning": "test", "estimated_difficulty": "低", "potential_risks": []}'
+        _patch_llm(monkeypatch, mock_response)
+        from tools.plan import aplan
+
+        result = asyncio.get_event_loop().run_until_complete(
+            aplan("异步规划测试")
+        )
+
+        assert "plan_id" in result
+        assert result["total_steps"] == 1
+        assert result["steps"][0]["description"] == "Async step"
+
+    def test_aplan_input_validation(self, monkeypatch):
+        _patch_llm(monkeypatch, "unexpected")
+        from tools.plan import aplan
+
+        result = asyncio.get_event_loop().run_until_complete(aplan(""))
+        assert "error" in result
+        assert "empty" in result["error"]
+
+    def test_aplan_llm_error(self, monkeypatch):
+        _patch_llm(monkeypatch, RuntimeError("async error"))
+        from tools.plan import aplan
+
+        result = asyncio.get_event_loop().run_until_complete(
+            aplan("分析项目")
+        )
+        assert "error" in result
+        assert "LLM" in result["error"]
+
+
+class TestPlanRegistration:
+    """测试工具注册"""
+
+    def test_plan_registered(self):
         import tools.registry as registry_module
 
         registry_module._registry = None
         reg = registry_module.get_tool_registry()
+        assert "plan" in reg._tools
 
-        tool_names = list(reg._tools.keys())
-        assert "plan" in tool_names
-        assert "read_file" in tool_names
-        assert "list_files" in tool_names
-
-    def test_plan_tool_in_tool_list(self):
-        """验证 plan 工具在工具列表中"""
+    def test_plan_tool_list(self):
         import tools.registry as registry_module
 
         registry_module._registry = None
@@ -175,60 +269,26 @@ class TestPlanToolRegistration:
         tool_list = reg.get_tool_list()
         plan_tool = next((t for t in tool_list if t["function"]["name"] == "plan"), None)
         assert plan_tool is not None
-        assert "goal" in plan_tool["function"]["parameters"]["properties"]
-        assert "current_state" in plan_tool["function"]["parameters"]["properties"]
-        assert "constraints" in plan_tool["function"]["parameters"]["properties"]
-
-    def test_plan_tool_executable(self, monkeypatch):
-        """测试通过 registry 执行 plan 工具"""
-        mock_response = '{"steps": [{"step": 1, "description": "Test step", "reasoning": "Test", "complexity": "低"}], "total_steps": 1, "reasoning": "Test", "estimated_difficulty": "低", "potential_risks": []}'
-
-        class MockLLM:
-            def __init__(self):
-                pass
-
-            def chat(self, msgs):
-                return mock_response
-
-        mock_module = type("MockLLMClientModule", (), {"NanoLLMClient": MockLLM})()
-        monkeypatch.setitem(sys.modules, "llm.client", mock_module)
-
-        import tools.registry as registry_module
-
-        registry_module._registry = None
-        reg = registry_module.get_tool_registry()
-
-        result = reg.execute("plan", {"goal": "测试目标"})
-        assert "plan_id" in result
-        assert "steps" in result
-        assert result["total_steps"] == 1
-
-
-class TestPlanSchema:
-    """测试规划工具的 schema"""
-
-    def test_plan_schema_goal_required(self):
-        """验证 goal 是必需参数"""
-        import tools.registry as registry_module
-
-        registry_module._registry = None
-        reg = registry_module.get_tool_registry()
-
-        tool = reg._tools["plan"]
-        required = tool["schema"]["required"]
-        assert "goal" in required
-
-    def test_plan_schema_optional_params(self):
-        """验证 current_state 和 constraints 是可选参数"""
-        import tools.registry as registry_module
-
-        registry_module._registry = None
-        reg = registry_module.get_tool_registry()
-
-        tool = reg._tools["plan"]
-        props = tool["schema"]["properties"]
+        props = plan_tool["function"]["parameters"]["properties"]
         assert "goal" in props
         assert "current_state" in props
         assert "constraints" in props
-        assert "default" in props["current_state"]
+
+    def test_plan_goal_required(self):
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        tool = reg._tools["plan"]
+        assert "goal" in tool["schema"]["required"]
+
+    def test_plan_optional_defaults(self):
+        import tools.registry as registry_module
+
+        registry_module._registry = None
+        reg = registry_module.get_tool_registry()
+
+        props = reg._tools["plan"]["schema"]["properties"]
         assert props["current_state"]["default"] is None
+        assert props["constraints"]["default"] is None

--- a/tools/plan.py
+++ b/tools/plan.py
@@ -3,6 +3,22 @@
 import uuid
 from typing import Any, Dict, List, Optional
 
+from core.utils import extract_json
+
+# 模块级 LLM client，复用避免每次调用重新初始化
+_llm_client: Optional[Any] = None
+
+
+def _get_llm() -> Any:
+    """获取复用的 LLM client"""
+    global _llm_client
+    if _llm_client is None:
+        from llm.client import NanoLLMClient
+
+        _llm_client = NanoLLMClient()
+    return _llm_client
+
+
 PLANNER_PROMPT = """将目标分解为 3-8 个可执行步骤。
 
 目标: {goal}
@@ -45,9 +61,7 @@ def _validate_and_build_prompt(
         else ""
     )
     const_str = (
-        "\n约束: " + ", ".join(f"{c}" for c in constraints)
-        if constraints
-        else ""
+        "\n约束: " + ", ".join(f"{c}" for c in constraints) if constraints else ""
     )
 
     prompt = PLANNER_PROMPT.format(
@@ -101,10 +115,7 @@ def plan(
 
     # 调用 LLM
     try:
-        from llm.client import NanoLLMClient
-
-        llm = NanoLLMClient()
-        response = llm.chat([{"role": "user", "content": prompt}])
+        response = _get_llm().chat([{"role": "user", "content": prompt}])
     except Exception as e:
         return {
             "error": f"LLM 调用失败: {e}",
@@ -115,9 +126,7 @@ def plan(
 
     # 解析 JSON
     try:
-        import llm.client as _llm_client
-
-        result = _llm_client._extract_json(response)
+        result = extract_json(response)
         if "steps" not in result or not isinstance(result.get("steps"), list):
             result["steps"] = []
         result["total_steps"] = len(result["steps"])
@@ -174,10 +183,7 @@ async def aplan(
     prompt, plan_id = _validate_and_build_prompt(goal, current_state, constraints)
 
     try:
-        from llm.client import NanoLLMClient
-
-        llm = NanoLLMClient()
-        response = await llm.achat([{"role": "user", "content": prompt}])
+        response = await _get_llm().achat([{"role": "user", "content": prompt}])
     except Exception as e:
         return {
             "error": f"LLM 调用失败: {e}",
@@ -187,9 +193,7 @@ async def aplan(
         }
 
     try:
-        import llm.client as _llm_client
-
-        result = _llm_client._extract_json(response)
+        result = extract_json(response)
         if "steps" not in result or not isinstance(result.get("steps"), list):
             result["steps"] = []
         result["total_steps"] = len(result["steps"])

--- a/tools/plan.py
+++ b/tools/plan.py
@@ -1,92 +1,61 @@
 """规划工具 - 将复杂目标分解为结构化执行步骤"""
 
-import json
 import uuid
 from typing import Any, Dict, List, Optional
 
+PLANNER_PROMPT = """将目标分解为 3-8 个可执行步骤。
 
-PLANNER_PROMPT = """你是一个任务规划专家。你的职责是将复杂目标分解为清晰、可执行的步骤。
-
-## 输入信息
 目标: {goal}
+{current_state}{constraints}
 
-{current_state}
-{constraints}
-
-## 分解要求
-1. 将目标分解为 3-8 个具体、可执行的步骤
-2. 每个步骤应该能通过单次工具调用或少量操作完成
-3. 考虑步骤之间的依赖关系和执行顺序
-4. 识别关键决策点和可能的备选方案
-5. 评估每个步骤的复杂度（低/中/高）
-
-## 输出格式
-请严格以 JSON 格式返回计划，不要包含任何其他文字：
-
+输出严格 JSON 格式:
 {{
   "steps": [
     {{
       "step": 1,
-      "description": "步骤的清晰描述",
-      "reasoning": "为什么需要这个步骤",
+      "description": "步骤描述",
+      "reasoning": "为什么需要此步骤",
       "complexity": "低/中/高",
-      "alternative": "如果此步骤失败时的备选方案（可选）"
+      "alternative": "失败时的备选方案（可选）"
     }}
   ],
   "total_steps": N,
-  "reasoning": "整体规划思路，解释为什么按此顺序执行",
-  "estimated_difficulty": "整体难度评估",
-  "potential_risks": ["风险1", "风险2（可选）"]
+  "reasoning": "整体规划思路",
+  "estimated_difficulty": "低/中/高",
+  "potential_risks": ["风险列表（可选）"]
 }}
 
-## 示例
-目标: "为项目添加用户认证功能"
-输出:
-{{
-  "steps": [
-    {{
-      "step": 1,
-      "description": "分析现有代码结构，找到认证相关的现有代码",
-      "reasoning": "需要先了解项目架构，避免重复造轮子",
-      "complexity": "低",
-      "alternative": null
-    }},
-    {{
-      "step": 2,
-      "description": "设计用户数据模型和认证流程",
-      "reasoning": "需要先确定数据结构和认证机制",
-      "complexity": "中",
-      "alternative": "使用现成的认证库如 Authlib"
-    }},
-    {{
-      "step": 3,
-      "description": "实现登录/注册 API 端点",
-      "reasoning": "核心功能，需要先完成",
-      "complexity": "中",
-      "alternative": null
-    }},
-    {{
-      "step": 4,
-      "description": "添加会话管理和 JWT token",
-      "reasoning": "无状态认证，便于扩展",
-      "complexity": "中",
-      "alternative": "使用 session-based 认证"
-    }},
-    {{
-      "step": 5,
-      "description": "编写单元测试覆盖认证流程",
-      "reasoning": "确保关键功能正确",
-      "complexity": "低",
-      "alternative": null
-    }}
-  ],
-  "total_steps": 5,
-  "reasoning": "遵循先分析、后设计、再实现的顺序，确保架构合理",
-  "estimated_difficulty": "中",
-  "potential_risks": ["第三方认证库的依赖版本问题"]
-}}
+直接输出 JSON，不要有其他文字。"""
 
-现在开始分解你的目标。直接输出 JSON，不要有其他文字。"""
+
+def _validate_and_build_prompt(
+    goal: str,
+    current_state: Optional[Dict[str, Any]],
+    constraints: Optional[List[str]],
+) -> tuple[str, str]:
+    """验证输入并构建提示词，返回 (prompt, plan_id)"""
+    plan_id = str(uuid.uuid4())[:8]
+
+    if not goal or not goal.strip():
+        return "", plan_id
+
+    state_str = (
+        "\n当前状态: " + ", ".join(f"{k}={v}" for k, v in current_state.items())
+        if current_state
+        else ""
+    )
+    const_str = (
+        "\n约束: " + ", ".join(f"{c}" for c in constraints)
+        if constraints
+        else ""
+    )
+
+    prompt = PLANNER_PROMPT.format(
+        goal=goal,
+        current_state=state_str,
+        constraints=const_str,
+    )
+    return prompt, plan_id
 
 
 def plan(
@@ -98,33 +67,39 @@ def plan(
     Decomposes a complex goal into structured execution steps.
 
     Args:
-        goal: The high-level goal to decompose into actionable steps
-        current_state: Current context (e.g., files modified, completed steps, environment info)
-        constraints: List of constraints or requirements (e.g., "must use async", "max 5 steps")
+        goal: The high-level goal to decompose
+        current_state: Current context (e.g., files modified, completed steps)
+        constraints: List of constraints (e.g., "must use async", "max 5 steps")
 
     Returns:
-        Dict containing the structured plan with steps, reasoning, and metadata
+        Dict with steps, reasoning, and metadata
     """
-    # 构建提示词
-    if current_state:
-        state_lines = "当前状态:\n" + "\n".join(
-            f"- {k}: {v}" for k, v in current_state.items()
-        )
-    else:
-        state_lines = "当前状态: 无（从头开始）"
+    # 输入验证
+    if not goal or not goal.strip():
+        return {
+            "error": "goal cannot be empty",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
+    if current_state is not None and not isinstance(current_state, dict):
+        return {
+            "error": "current_state must be a dict",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
+    if constraints is not None and not isinstance(constraints, list):
+        return {
+            "error": "constraints must be a list",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
 
-    if constraints:
-        constraint_lines = "约束条件:\n" + "\n".join(f"- {c}" for c in constraints)
-    else:
-        constraint_lines = "约束条件: 无"
+    prompt, plan_id = _validate_and_build_prompt(goal, current_state, constraints)
 
-    prompt = PLANNER_PROMPT.format(
-        goal=goal,
-        current_state=state_lines,
-        constraints=constraint_lines,
-    )
-
-    # 调用 LLM 生成计划
+    # 调用 LLM
     try:
         from llm.client import NanoLLMClient
 
@@ -135,14 +110,17 @@ def plan(
             "error": f"LLM 调用失败: {e}",
             "steps": [],
             "total_steps": 0,
-            "plan_id": str(uuid.uuid4())[:8],
+            "plan_id": plan_id,
         }
 
-    # 解析 LLM 返回的 JSON
-    plan_id = str(uuid.uuid4())[:8]
+    # 解析 JSON
     try:
-        # 尝试从响应中提取 JSON
-        result = _extract_json(response)
+        import llm.client as _llm_client
+
+        result = _llm_client._extract_json(response)
+        if "steps" not in result or not isinstance(result.get("steps"), list):
+            result["steps"] = []
+        result["total_steps"] = len(result["steps"])
         result["plan_id"] = plan_id
         return result
     except Exception as e:
@@ -155,16 +133,73 @@ def plan(
         }
 
 
-def _extract_json(text: str) -> Dict[str, Any]:
-    """从文本中提取 JSON 对象"""
-    # 尝试直接解析
-    text = text.strip()
+async def aplan(
+    goal: str,
+    current_state: Optional[Dict[str, Any]] = None,
+    constraints: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Async version of plan - decomposes a complex goal into structured execution steps.
 
-    # 查找 JSON 对象的起始和结束
-    start = text.find("{")
-    end = text.rfind("}")
-    if start != -1 and end > start:
-        json_str = text[start : end + 1]
-        return json.loads(json_str)
+    Args:
+        goal: The high-level goal to decompose
+        current_state: Current context
+        constraints: List of constraints
 
-    raise ValueError("No JSON object found in response")
+    Returns:
+        Dict with steps, reasoning, and metadata
+    """
+    if not goal or not goal.strip():
+        return {
+            "error": "goal cannot be empty",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
+    if current_state is not None and not isinstance(current_state, dict):
+        return {
+            "error": "current_state must be a dict",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
+    if constraints is not None and not isinstance(constraints, list):
+        return {
+            "error": "constraints must be a list",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
+
+    prompt, plan_id = _validate_and_build_prompt(goal, current_state, constraints)
+
+    try:
+        from llm.client import NanoLLMClient
+
+        llm = NanoLLMClient()
+        response = await llm.achat([{"role": "user", "content": prompt}])
+    except Exception as e:
+        return {
+            "error": f"LLM 调用失败: {e}",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": plan_id,
+        }
+
+    try:
+        import llm.client as _llm_client
+
+        result = _llm_client._extract_json(response)
+        if "steps" not in result or not isinstance(result.get("steps"), list):
+            result["steps"] = []
+        result["total_steps"] = len(result["steps"])
+        result["plan_id"] = plan_id
+        return result
+    except Exception as e:
+        return {
+            "error": f"解析计划失败: {e}",
+            "raw_response": response[:500],
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": plan_id,
+        }

--- a/tools/plan.py
+++ b/tools/plan.py
@@ -1,0 +1,170 @@
+"""规划工具 - 将复杂目标分解为结构化执行步骤"""
+
+import json
+import uuid
+from typing import Any, Dict, List, Optional
+
+
+PLANNER_PROMPT = """你是一个任务规划专家。你的职责是将复杂目标分解为清晰、可执行的步骤。
+
+## 输入信息
+目标: {goal}
+
+{current_state}
+{constraints}
+
+## 分解要求
+1. 将目标分解为 3-8 个具体、可执行的步骤
+2. 每个步骤应该能通过单次工具调用或少量操作完成
+3. 考虑步骤之间的依赖关系和执行顺序
+4. 识别关键决策点和可能的备选方案
+5. 评估每个步骤的复杂度（低/中/高）
+
+## 输出格式
+请严格以 JSON 格式返回计划，不要包含任何其他文字：
+
+{{
+  "steps": [
+    {{
+      "step": 1,
+      "description": "步骤的清晰描述",
+      "reasoning": "为什么需要这个步骤",
+      "complexity": "低/中/高",
+      "alternative": "如果此步骤失败时的备选方案（可选）"
+    }}
+  ],
+  "total_steps": N,
+  "reasoning": "整体规划思路，解释为什么按此顺序执行",
+  "estimated_difficulty": "整体难度评估",
+  "potential_risks": ["风险1", "风险2（可选）"]
+}}
+
+## 示例
+目标: "为项目添加用户认证功能"
+输出:
+{{
+  "steps": [
+    {{
+      "step": 1,
+      "description": "分析现有代码结构，找到认证相关的现有代码",
+      "reasoning": "需要先了解项目架构，避免重复造轮子",
+      "complexity": "低",
+      "alternative": null
+    }},
+    {{
+      "step": 2,
+      "description": "设计用户数据模型和认证流程",
+      "reasoning": "需要先确定数据结构和认证机制",
+      "complexity": "中",
+      "alternative": "使用现成的认证库如 Authlib"
+    }},
+    {{
+      "step": 3,
+      "description": "实现登录/注册 API 端点",
+      "reasoning": "核心功能，需要先完成",
+      "complexity": "中",
+      "alternative": null
+    }},
+    {{
+      "step": 4,
+      "description": "添加会话管理和 JWT token",
+      "reasoning": "无状态认证，便于扩展",
+      "complexity": "中",
+      "alternative": "使用 session-based 认证"
+    }},
+    {{
+      "step": 5,
+      "description": "编写单元测试覆盖认证流程",
+      "reasoning": "确保关键功能正确",
+      "complexity": "低",
+      "alternative": null
+    }}
+  ],
+  "total_steps": 5,
+  "reasoning": "遵循先分析、后设计、再实现的顺序，确保架构合理",
+  "estimated_difficulty": "中",
+  "potential_risks": ["第三方认证库的依赖版本问题"]
+}}
+
+现在开始分解你的目标。直接输出 JSON，不要有其他文字。"""
+
+
+def plan(
+    goal: str,
+    current_state: Optional[Dict[str, Any]] = None,
+    constraints: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Decomposes a complex goal into structured execution steps.
+
+    Args:
+        goal: The high-level goal to decompose into actionable steps
+        current_state: Current context (e.g., files modified, completed steps, environment info)
+        constraints: List of constraints or requirements (e.g., "must use async", "max 5 steps")
+
+    Returns:
+        Dict containing the structured plan with steps, reasoning, and metadata
+    """
+    # 构建提示词
+    if current_state:
+        state_lines = "当前状态:\n" + "\n".join(
+            f"- {k}: {v}" for k, v in current_state.items()
+        )
+    else:
+        state_lines = "当前状态: 无（从头开始）"
+
+    if constraints:
+        constraint_lines = "约束条件:\n" + "\n".join(f"- {c}" for c in constraints)
+    else:
+        constraint_lines = "约束条件: 无"
+
+    prompt = PLANNER_PROMPT.format(
+        goal=goal,
+        current_state=state_lines,
+        constraints=constraint_lines,
+    )
+
+    # 调用 LLM 生成计划
+    try:
+        from llm.client import NanoLLMClient
+
+        llm = NanoLLMClient()
+        response = llm.chat([{"role": "user", "content": prompt}])
+    except Exception as e:
+        return {
+            "error": f"LLM 调用失败: {e}",
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": str(uuid.uuid4())[:8],
+        }
+
+    # 解析 LLM 返回的 JSON
+    plan_id = str(uuid.uuid4())[:8]
+    try:
+        # 尝试从响应中提取 JSON
+        result = _extract_json(response)
+        result["plan_id"] = plan_id
+        return result
+    except Exception as e:
+        return {
+            "error": f"解析计划失败: {e}",
+            "raw_response": response[:500],
+            "steps": [],
+            "total_steps": 0,
+            "plan_id": plan_id,
+        }
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    """从文本中提取 JSON 对象"""
+    # 尝试直接解析
+    text = text.strip()
+
+    # 查找 JSON 对象的起始和结束
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        json_str = text[start : end + 1]
+        return json.loads(json_str)
+
+    raise ValueError("No JSON object found in response")

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1,6 +1,7 @@
 """工具注册表 - 精简版"""
 
 import inspect
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -70,7 +71,6 @@ class ToolRegistry:
         self, tool_name: str, arguments: Dict[str, Any]
     ) -> Dict[str, Any]:
         """映射参数名，处理常见的参数名差异"""
-        # 修复映射逻辑：将外部参数名映射到内部参数名
         param_mappings = {
             "read_file": {"filename": "path", "absolute_path": "path"},
             "list_files": {"directory": "path", "dir": "path"},
@@ -231,7 +231,6 @@ def _register_tools(registry: ToolRegistry):
             r":\(\)\{\:\|:&\};:",
             r"mkfs",
         ]
-        import re
 
         if any(
             re.search(pattern, command, re.IGNORECASE) for pattern in dangerous_patterns
@@ -267,3 +266,12 @@ def _register_tools(registry: ToolRegistry):
         "Replaces first occurrence of old_str with new_str in file",
     )
     registry.register("run_bash", run_bash, "Executes bash command in sandbox")
+
+    # 注册规划工具
+    from tools.plan import plan
+
+    registry.register(
+        "plan",
+        plan,
+        "Decomposes a complex goal into structured execution steps",
+    )


### PR DESCRIPTION
## Summary

- Add `plan(goal, current_state?, constraints?)` tool for LLM-powered goal decomposition
- Add `aplan()` async version with full asyncio support
- Input validation: empty goal, invalid types for current_state/constraints
- Response validation: ensure steps is a list, handle missing/extra fields gracefully

### Refactoring (deduplication)

- Extract `ExecutionContext` base class (`ChainContext`/`RouteContext` inherit from it)
- Move `extract_json` to `core/utils.py`, reuse in `llm/client.py` and `tools/plan.py`
- Refactor `plan.py` to reuse module-level LLM client singleton
- Fix async plan tests: `asyncio.run()` replaces deprecated `get_event_loop()`
- Fix E402: keep bottom-of-file import in `llm/client.py` with noqa

## Test plan

- [x] `uv run pytest tests/test_plan.py` - 23 tests pass
- [x] `uv run pytest tests/test_chain.py` - 10 tests pass
- [x] `uv run pytest tests/test_router.py` - 33 tests pass
- [x] `uv run ruff check .` - all checks pass
- [x] `uv run ruff format .` - formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added goal planner tool that converts objectives into structured execution plans with 3-8 steps (available in both synchronous and asynchronous modes)
  * Improved JSON extraction utility for more reliable parsing of LLM responses

* **Refactor**
  * Centralized execution context model across modules for consistent state management

* **Tests**
  * Added comprehensive test suite covering planner functionality and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->